### PR TITLE
docker-compose.ymlにアーキテクチャの指定を追加

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,6 @@ services:
       context: .
       dockerfile: Dockerfile
     container_name: vulnerable_sudo_app
+    platform: linux/amd64
     tty: true
     stdin_open: true
-


### PR DESCRIPTION
`docker-compose.yml` にアーキテクチャ指定を追加し、どのプラットフォームでも `amd64` を使用するようにした。